### PR TITLE
Support Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:18-slim
+
+WORKDIR /app
+
+COPY package.json ./
+COPY pnpm-lock.yaml ./
+RUN corepack enable --install-directory=/usr/bin \
+    && corepack prepare --activate pnpm@latest
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm run build
+RUN rm -rf node_modules
+RUN pnpm install --frozen-lockfile --prod
+
+# runtime image
+FROM node:18-alpine
+
+ENV TZ="Asia/Shanghai"
+
+WORKDIR /app
+COPY package.json .
+COPY public /app/public
+COPY --from=0 /app/node_modules /app/node_modules
+COPY --from=0 /app/dist /app/dist
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
I agree with #9, deploy with docker is easy for who don't want to install node.js in their server. 